### PR TITLE
Tasks that return invalid targets (step_id)

### DIFF
--- a/django_workflow_engine/executor.py
+++ b/django_workflow_engine/executor.py
@@ -156,12 +156,11 @@ class WorkflowExecutor:
                 Target.objects.get_or_create(
                     task_status=task_status, target_string=target
                 )
-                # Unset the executed fields so that the task will be picked up again.
-
                 workflow_step = self.flow.workflow.get_step(step_id=target)
                 if not workflow_step:
                     raise WorkflowError(f"Step '{target}' not found in workflow")
                 next_task_status, _ = self.get_or_create_task_status(step=workflow_step)
+                # Unset the executed fields so that the task will be picked up again.
                 next_task_status.executed_at = None
                 next_task_status.executed_by = None
                 next_task_status.save(

--- a/django_workflow_engine/executor.py
+++ b/django_workflow_engine/executor.py
@@ -156,15 +156,15 @@ class WorkflowExecutor:
                 Target.objects.get_or_create(
                     task_status=task_status, target_string=target
                 )
+                # Unset the executed fields so that the task will be picked up again.
+
                 workflow_step = self.flow.workflow.get_step(step_id=target)
                 if not workflow_step:
                     raise WorkflowError(f"Step '{target}' not found in workflow")
-
-                task_status, _ = self.get_or_create_task_status(step=workflow_step)
-                # Unset the executed fields so that the task will be picked up again.
-                task_status.executed_at = None
-                task_status.executed_by = None
-                task_status.save(
+                next_task_status, _ = self.get_or_create_task_status(step=workflow_step)
+                next_task_status.executed_at = None
+                next_task_status.executed_by = None
+                next_task_status.save(
                     update_fields=[
                         "executed_at",
                         "executed_by",

--- a/django_workflow_engine/executor.py
+++ b/django_workflow_engine/executor.py
@@ -156,18 +156,20 @@ class WorkflowExecutor:
                 Target.objects.get_or_create(
                     task_status=task_status, target_string=target
                 )
-            for workflow_step in self.flow.workflow.steps:
-                if workflow_step.step_id in targets:
-                    task_status, _ = self.get_or_create_task_status(step=workflow_step)
-                    # Unset the executed fields so that the task will be picked up again.
-                    task_status.executed_at = None
-                    task_status.executed_by = None
-                    task_status.save(
-                        update_fields=[
-                            "executed_at",
-                            "executed_by",
-                        ]
-                    )
+                workflow_step = self.flow.workflow.get_step(step_id=target)
+                if not workflow_step:
+                    raise WorkflowError(f"Step '{target}' not found in workflow")
+
+                task_status, _ = self.get_or_create_task_status(step=workflow_step)
+                # Unset the executed fields so that the task will be picked up again.
+                task_status.executed_at = None
+                task_status.executed_by = None
+                task_status.save(
+                    update_fields=[
+                        "executed_at",
+                        "executed_by",
+                    ]
+                )
 
         # Break the flow if this task is the last in a loop or if the task isn't done or if this step is in the target list.
         if (

--- a/django_workflow_engine/tests/tasks.py
+++ b/django_workflow_engine/tests/tasks.py
@@ -86,3 +86,11 @@ class WasUserCreatedTaskB(Task):
             return ["task_b_remind_creator"], False
 
         return ["task_b_notify_creator"], True
+
+
+class InvalidTargetTask(Task):
+    task_name = "invalid_target_task"
+    auto = True
+
+    def execute(self, task_info):
+        return ["not_a_real_step_id"], True

--- a/django_workflow_engine/tests/test_workflows/test_tasks.py
+++ b/django_workflow_engine/tests/test_workflows/test_tasks.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 import pytest
 
 from django_workflow_engine.models import TaskStatus
@@ -5,20 +7,27 @@ from django_workflow_engine.tests.utils import set_up_flow
 from django_workflow_engine.tests.workflows import invalid_task_target_workflow
 
 
+@mock.patch("django_workflow_engine.executor.logger.exception")
 @pytest.mark.django_db
-def test_invalid_target(settings):
+def test_invalid_target(mock_exception, settings):
     flow, executor, test_user = set_up_flow(
         settings,
         invalid_task_target_workflow,
     )
     executor.run_flow(user=test_user)
 
+    # Check that a WorkflowError was logged.
+    mock_exception.assert_called_once()
+    assert (
+        str(mock_exception.call_args[0][0])
+        == "Step 'not_a_real_step_id' not found in workflow"
+    )
+
     assert TaskStatus.objects.count() == 2
 
     correct_task_order = [
         "start",
         "task_a",
-        # Task B fails to run because it's target is invalid
     ]
 
     task_order = [task_status.step_id for task_status in TaskStatus.objects.all()]

--- a/django_workflow_engine/tests/test_workflows/test_tasks.py
+++ b/django_workflow_engine/tests/test_workflows/test_tasks.py
@@ -1,0 +1,25 @@
+import pytest
+
+from django_workflow_engine.models import TaskStatus
+from django_workflow_engine.tests.utils import set_up_flow
+from django_workflow_engine.tests.workflows import invalid_task_target_workflow
+
+
+@pytest.mark.django_db
+def test_invalid_target(settings):
+    flow, executor, test_user = set_up_flow(
+        settings,
+        invalid_task_target_workflow,
+    )
+    executor.run_flow(user=test_user)
+
+    assert TaskStatus.objects.count() == 2
+
+    correct_task_order = [
+        "start",
+        "task_a",
+        # Task B fails to run because it's target is invalid
+    ]
+
+    task_order = [task_status.step_id for task_status in TaskStatus.objects.all()]
+    assert task_order == correct_task_order

--- a/django_workflow_engine/tests/workflows.py
+++ b/django_workflow_engine/tests/workflows.py
@@ -3,7 +3,7 @@ from django_workflow_engine.dataclass import Step, Workflow
 from django_workflow_engine.tasks.previous_tasks_complete import (
     PreviousTasksCompleteTask,
 )
-from django_workflow_engine.tests.tasks import BasicTask, PauseTask
+from django_workflow_engine.tests.tasks import BasicTask, InvalidTargetTask, PauseTask
 
 """
 Test workflow definitions
@@ -275,6 +275,29 @@ complex_loops_workflow = Workflow(
         ),
         Step(
             step_id="end",
+            task_name=BasicTask.task_name,
+            targets=COMPLETE,
+        ),
+    ],
+)
+
+
+invalid_task_target_workflow = Workflow(
+    name="invalid_task_target_workflow",
+    steps=[
+        Step(
+            step_id="start",
+            task_name=BasicTask.task_name,
+            start=True,
+            targets=["task_a"],
+        ),
+        Step(
+            step_id="task_a",
+            task_name=InvalidTargetTask.task_name,
+            targets=["task_b"],
+        ),
+        Step(
+            step_id="task_b",
             task_name=BasicTask.task_name,
             targets=COMPLETE,
         ),


### PR DESCRIPTION
When a Task returns a target that isn't a valid step ID the executor should not consider that task as executed